### PR TITLE
Cleanup

### DIFF
--- a/input.yyp
+++ b/input.yyp
@@ -340,7 +340,7 @@
     {"CopyToMask":-1,"filePath":"datafiles","resourceVersion":"1.0","name":"test_load_mapping.json","resourceType":"GMIncludedFile",},
   ],
   "MetaData": {
-    "IDEVersion": "2022.800.0.165",
+    "IDEVersion": "2022.800.0.161",
   },
   "resourceVersion": "1.6",
   "name": "input",

--- a/input.yyp
+++ b/input.yyp
@@ -340,7 +340,7 @@
     {"CopyToMask":-1,"filePath":"datafiles","resourceVersion":"1.0","name":"test_load_mapping.json","resourceType":"GMIncludedFile",},
   ],
   "MetaData": {
-    "IDEVersion": "2022.800.0.161",
+    "IDEVersion": "2022.800.0.165",
   },
   "resourceVersion": "1.6",
   "name": "input",

--- a/scripts/__input_class_gamepad/__input_class_gamepad.gml
+++ b/scripts/__input_class_gamepad/__input_class_gamepad.gml
@@ -205,26 +205,26 @@ function __input_class_gamepad(_index) constructor
     /// @param   {Real} _lstrength 0-1
     /// @param   {Real} _rstrength 0-1
     /// @param   {Real} _time in frames
-    static __haptic_vibrate = function(_strengthl, _strengthr, _frames)
+    static __haptic_vibrate = function(_strengthl, _strengthr, _duration)
     {
         __haptic_strength_left  = clamp(_strengthl, 0, 1);
         __haptic_strength_right = clamp(_strengthr, 0, 1);
         
         __haptic_time = 0;
-        __haptic_duration = (__haptic_strength_left + __haptic_strength_right) > 0 ? _frames : 0;
+        __haptic_duration = (__haptic_strength_left + __haptic_strength_right) > 0 ? _duration : 0;
         
         __haptic_curve = undefined;
     }
     
     /// @param {Asset.GMAnimCurve} _curve
-    /// @param {Real} _frames
-    static __haptic_vibrate_curve = function(_curve, _frames)
+    /// @param {Real} _duration
+    static __haptic_vibrate_curve = function(_curve, _duration)
     {
         __haptic_vibrate(0, 0, 0);
-        if ((_frames) > 0 && (_curve != undefined) || animcurve_exists(_curve))
+        if ((_duration) > 0 && (_curve != undefined) || animcurve_exists(_curve))
         {
             __haptic_curve    = _curve;
-            __haptic_duration = _frames;
+            __haptic_duration = _duration;
         }        
     }
     

--- a/scripts/__input_class_gamepad/__input_class_gamepad.gml
+++ b/scripts/__input_class_gamepad/__input_class_gamepad.gml
@@ -22,8 +22,8 @@ function __input_class_gamepad(_index) constructor
     axis_count   = undefined;
     hat_count    = undefined;
     
-    __haptic_step           = 0;
-    __haptic_steps_total    = 0;
+    __haptic_time           = 0;
+    __haptic_duration       = 0;
     __haptic_strength_left  = 0;
     __haptic_strength_right = 0;
     __haptic_curve          = undefined;    
@@ -210,8 +210,8 @@ function __input_class_gamepad(_index) constructor
         __haptic_strength_left  = clamp(_strengthl, 0, 1);
         __haptic_strength_right = clamp(_strengthr, 0, 1);
         
-        __haptic_step = 0;
-        __haptic_steps_total = (__haptic_strength_left + __haptic_strength_right) > 0 ? _frames : 0;
+        __haptic_time = 0;
+        __haptic_duration = (__haptic_strength_left + __haptic_strength_right) > 0 ? _frames : 0;
         
         __haptic_curve = undefined;
     }
@@ -223,14 +223,14 @@ function __input_class_gamepad(_index) constructor
         __haptic_vibrate(0, 0, 0);
         if ((_frames) > 0 && (_curve != undefined) || animcurve_exists(_curve))
         {
-            __haptic_curve       = _curve;
-            __haptic_steps_total = _frames;
+            __haptic_curve    = _curve;
+            __haptic_duration = _frames;
         }        
     }
     
     static __haptic_tick = function()
     {        
-        if ((__haptic_steps_total == 0) || (__haptic_step >= __haptic_steps_total))
+        if ((__haptic_duration == 0) || (__haptic_time >= __haptic_duration))
         {
             gamepad_set_vibration(index, 0, 0);
             __haptic_vibrate(0, 0, 0);
@@ -253,8 +253,8 @@ function __input_class_gamepad(_index) constructor
                     _channel_right = animcurve_get_channel(__haptic_curve, INPUT_VIBRATION_CHANNEL_RIGHT);
                 }
 
-                if (_channel_left  != -1) __haptic_strength_left  = animcurve_channel_evaluate(_channel_left,  __haptic_step/__haptic_steps_total);
-                if (_channel_right != -1) __haptic_strength_right = animcurve_channel_evaluate(_channel_right, __haptic_step/__haptic_steps_total);
+                if (_channel_left  != -1) __haptic_strength_left  = animcurve_channel_evaluate(_channel_left,  __haptic_time/__haptic_duration);
+                if (_channel_right != -1) __haptic_strength_right = animcurve_channel_evaluate(_channel_right, __haptic_time/__haptic_duration);
             }
 
             if (window_has_focus() && !os_is_paused())
@@ -266,7 +266,7 @@ function __input_class_gamepad(_index) constructor
                 gamepad_set_vibration(index, 0, 0);
             }
 
-            __haptic_step += (INPUT_TIMER_MILLISECONDS? (__input_get_time() - __input_get_previous_time()) : 1);
+            __haptic_time += (INPUT_TIMER_MILLISECONDS? (__input_get_time() - __input_get_previous_time()) : 1);
         }
     }
 }

--- a/scripts/__input_class_gamepad/__input_class_gamepad.gml
+++ b/scripts/__input_class_gamepad/__input_class_gamepad.gml
@@ -211,7 +211,7 @@ function __input_class_gamepad(_index) constructor
         __haptic_strength_right = clamp(_strengthr, 0, 1);
         
         __haptic_time = 0;
-        __haptic_duration = (__haptic_strength_left + __haptic_strength_right) > 0 ? _duration : 0;
+        __haptic_duration = (((__haptic_strength_left + __haptic_strength_right) > 0)? _duration : 0);
         
         __haptic_curve = undefined;
     }

--- a/scripts/input_vibrate/input_vibrate.gml
+++ b/scripts/input_vibrate/input_vibrate.gml
@@ -3,9 +3,9 @@
 /// @param   rightMotorSpeed
 /// @param   time
 /// @param   [playerIndex=0]
-function input_vibrate(_left_motor_speed, _right_motor_speed, _time, _player_index = 0)
+function input_vibrate(_left_motor_speed, _right_motor_speed, _duration, _player_index = 0)
 {
     __INPUT_VERIFY_PLAYER_INDEX
     
-    global.__input_players[_player_index].__haptic_vibrate(_left_motor_speed, _right_motor_speed, _time);
+    global.__input_players[_player_index].__haptic_vibrate(_left_motor_speed, _right_motor_speed, _duration);
 }

--- a/scripts/input_vibrate/input_vibrate.gml
+++ b/scripts/input_vibrate/input_vibrate.gml
@@ -1,7 +1,7 @@
 /// @desc Vibrates a player's controller for a duration, the units of which are determined by INPUT_TIMER_MILLISECONDS
 /// @param   leftMotorSpeed
 /// @param   rightMotorSpeed
-/// @param   time
+/// @param   duration
 /// @param   [playerIndex=0]
 function input_vibrate(_left_motor_speed, _right_motor_speed, _duration, _player_index = 0)
 {

--- a/scripts/input_vibrate_curve/input_vibrate_curve.gml
+++ b/scripts/input_vibrate_curve/input_vibrate_curve.gml
@@ -1,7 +1,7 @@
 /// @desc Vibrates a player's controller using animation curve channels for a duration, the units of which are determined by INPUT_TIMER_MILLISECONDS
 ///       Curves are evaluated if they contain one channel or individual channels per INPUT_VIBRATION_CHANNEL_LEFT and INPUT_VIBRATION_CHANNEL_RIGHT
 /// @param   animationCurve
-/// @param   time
+/// @param   duration
 /// @param   [playerIndex=0]
 function input_vibrate_curve(_curve, _duration, _player_index = 0)
 { 

--- a/scripts/input_vibrate_curve/input_vibrate_curve.gml
+++ b/scripts/input_vibrate_curve/input_vibrate_curve.gml
@@ -3,7 +3,7 @@
 /// @param   animationCurve
 /// @param   time
 /// @param   [playerIndex=0]
-function input_vibrate_curve(_curve, _time, _player_index = 0)
+function input_vibrate_curve(_curve, _duration, _player_index = 0)
 { 
     if (!is_real(_curve) || !is_struct(animcurve_get(_curve)))
     {
@@ -12,5 +12,5 @@ function input_vibrate_curve(_curve, _time, _player_index = 0)
     
     __INPUT_VERIFY_PLAYER_INDEX
 
-    global.__input_players[_player_index].__haptic_vibrate_curve(_curve, _time);
+    global.__input_players[_player_index].__haptic_vibrate_curve(_curve, _duration);
 }


### PR DESCRIPTION
Ambiguate haptic var names to reflect both frame/dt support

`__haptic_step` to `_haptic_time`, `__haptic_steps_total` to `__haptic_duration`